### PR TITLE
 Bump log4j-core from 2.13.0 to 2.16.0 in /src/aws/lambdas/incremental_distribution #11 

### DIFF
--- a/src/aws/lambdas/incremental_distribution/pom.xml
+++ b/src/aws/lambdas/incremental_distribution/pom.xml
@@ -144,7 +144,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>2.13.0</version>
+			<version>2.17.0</version>
 		</dependency>
 
 		<dependency>

--- a/src/aws/lambdas/incremental_distribution/pom.xml
+++ b/src/aws/lambdas/incremental_distribution/pom.xml
@@ -150,7 +150,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.13.0</version>
+			<version>2.17.0</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
 Bump log4j-core from 2.13.0 to 2.16.0 in /src/aws/lambdas/incremental_distribution #11 